### PR TITLE
Fix preprocessor name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub struct Preprocessor;
 
 impl mdbook::preprocess::Preprocessor for Preprocessor {
     fn name(&self) -> &str {
-        "alerts"
+        "callouts"
     }
 
     fn supports_renderer(&self, renderer: &str) -> bool {


### PR DESCRIPTION
Minor suggestion. The library name method returned 'alerts', changed to match current preprocessor name.

I noticed this while looking at your implementation.