### PR TITLE
Complete list of callout styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@
 > [!NOTE]
 > Highlights information that users should take into account, even when skimming.
 
+> [!ABSTRACT]
+> A summary or abstract of the information the user is reading.
+
+> [!TODO]
+> A reminder of an action to take at a later time.
+
 > [!TIP]
 > Optional information to help a user be more successful.
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -44,6 +44,22 @@
   --mdbook-callouts-icon: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLWluZm8iPjxjaXJjbGUgY3g9IjEyIiBjeT0iMTIiIHI9IjEwIi8+PHBhdGggZD0iTTEyIDE2di00Ii8+PHBhdGggZD0iTTEyIDhoLjAxIi8+PC9zdmc+');
 }
 
+.mdbook-callouts-abstract,
+.mdbook-callouts-summary,
+.mdbook-callouts-tldr {
+  --mdbook-callouts-color: rgb(var(--color-cyan-rgb));
+  --mdbook-callouts-background: rgba(var(--color-cyan-rgb), 0.1);
+  /* https://lucide.dev/icons/clipboard-list */
+  --mdbook-callouts-icon: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLWNsaXBib2FyZC1saXN0Ij48cmVjdCB3aWR0aD0iOCIgaGVpZ2h0PSI0IiB4PSI4IiB5PSIyIiByeD0iMSIgcnk9IjEiLz48cGF0aCBkPSJNMTYgNGgyYTIgMiAwIDAgMSAyIDJ2MTRhMiAyIDAgMCAxLTIgMkg2YTIgMiAwIDAgMS0yLTJWNmEyIDIgMCAwIDEgMi0yaDIiLz48cGF0aCBkPSJNMTIgMTFoNCIvPjxwYXRoIGQ9Ik0xMiAxNmg0Ii8+PHBhdGggZD0iTTggMTFoLjAxIi8+PHBhdGggZD0iTTggMTZoLjAxIi8+PC9zdmc+');
+}
+
+.mdbook-callouts-todo {
+  --mdbook-callouts-color: rgb(var(--color-blue-rgb));
+  --mdbook-callouts-background: rgba(var(--color-blue-rgb), 0.1);
+  /* https://lucide.dev/icons/check-circle-2 */
+  --mdbook-callouts-icon: url('data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJsdWNpZGUgbHVjaWRlLWNoZWNrLWNpcmNsZS0yIj48Y2lyY2xlIGN4PSIxMiIgY3k9IjEyIiByPSIxMCIvPjxwYXRoIGQ9Im05IDEyIDIgMiA0LTQiLz48L3N2Zz4=');
+}
+
 .mdbook-callouts-note {
   --mdbook-callouts-color: rgb(var(--color-blue-rgb));
   --mdbook-callouts-background: rgba(var(--color-blue-rgb), 0.1);
@@ -85,7 +101,8 @@
 }
 
 .mdbook-callouts-warning,
-.mdbook-callouts-warn {
+.mdbook-callouts-warn,
+.mdbook-callouts-attention {
   --mdbook-callouts-color: rgb(var(--color-orange-rgb));
   --mdbook-callouts-background: rgba(var(--color-orange-rgb), 0.1);
   /* https://lucide.dev/icons/alert-triangle */


### PR DESCRIPTION
I had been considering writing this preprocessor for a while because I find Obsidian callouts cleaner than the mdbook-admonish style. Since I found your implementation before I started mine, I tried it.

Unfortunately, I was using a few styles that you did not yet support. Added these styles to complete the Obsidian styles (https://help.obsidian.md/Editing+and+formatting/Callouts#Supported%20types).

- The 'abstract' style was missing with 'summary' and 'tldr' as aliases
- The 'todo' style was missing.
- 'attention' is an alias for 'warning'.

I did not change either of the styles that were aliases in Obsidian, that you separated out.